### PR TITLE
feat: scope settlement-notice silencing via settlementSilence config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ dsh plugin --profile web remove @dsh-external/dsh-sidechain
 | `providerName` | `fork` | 用于创建子会话的 subagent provider |
 | `persona` | 内置侧会话 persona | 侧会话的行为约束；空字符串表示沿用部署 persona |
 | `readOnlyTools` | 未设置 | 可选工具 allow-list，例如 `['read', 'grep', 'glob']` |
+| `settlementSilence` | `all` | `subagent-settled` 通知的抑制范围：`all` = 静默所有子会话的结算簿记通知（历史行为）；`side-children` = 只静默本插件注册的侧会话子级，编排工作流（如 subagent 并行下放）的完成通知正常投递给父会话 |
 
 配置示例：
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import z from '@deepseek-ai/schemastery'
 import type { ToolRestriction } from '@deepseek-ai/dsh-tools'
 import { createSidechainCommands } from './commands.ts'
 import { SIDE_PERSONA } from './prompts.ts'
-import { createSettlementSilence } from './settle-silence.ts'
+import { createSettlementSilence, type SettlementNoticeScope } from './settle-silence.ts'
 import type { SideDeps } from './side.ts'
 
 export const name = 'dsh-sidechain'
@@ -31,12 +31,20 @@ export interface Config {
   persona: string
   /** Optional allow-list of tool names kept visible in side conversations. */
   readOnlyTools?: string[]
+  /**
+   * Which runtime `subagent-settled` notices to suppress: `all` (default)
+   * silences every child's settlement bookkeeping; `side-children` silences
+   * only this plugin's registered side children so orchestration workflows
+   * that depend on settlement delivery keep receiving them.
+   */
+  settlementSilence?: SettlementNoticeScope
 }
 
 export const Config: z<Config> = z.object({
   providerName: z.string().default('fork'),
   persona: z.string().default(SIDE_PERSONA),
   readOnlyTools: z.array(z.string()),
+  settlementSilence: z.union([z.const('all'), z.const('side-children')]).default('all'),
 })
 
 export function apply(ctx: Context, config: Config): () => void {
@@ -49,7 +57,7 @@ export function apply(ctx: Context, config: Config): () => void {
     ...(config.persona === '' ? {} : { persona: config.persona }),
     ...(toolFilter === undefined ? {} : { toolFilter }),
   }
-  const settlementSilence = createSettlementSilence(ctx)
+  const settlementSilence = createSettlementSilence(ctx, config.settlementSilence)
   // Commands are an optional surface: without a command registry the plugin
   // still loads harmlessly in minimal deployments.
   ctx.inject(['commands'], (commandCtx) => {

--- a/src/settle-silence.ts
+++ b/src/settle-silence.ts
@@ -6,9 +6,12 @@
  * Session log.
  *
  * Child identity is persisted under DSH_HOME so resumed parents still reject
- * authored reports from side children created before a restart. Runtime
- * settlement notices are always suppressed because they are bookkeeping, not
- * user input; ordinary messages and other subagent reports remain unchanged.
+ * authored reports from side children created before a restart. Settlement
+ * notice suppression is configurable: `all` (default, legacy behavior) drops
+ * every runtime `subagent-settled` notice as bookkeeping, while
+ * `side-children` drops only notices from children this plugin registered, so
+ * orchestration workflows that rely on settlement delivery (e.g. background
+ * subagent fan-out coordinated by the parent model) keep working.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
@@ -65,19 +68,40 @@ interface SettlementSource {
   senderSessionId?: string | undefined
 }
 
-function isSideChildDelivery(message: UserMessage, children: ReadonlySet<SessionId>): boolean {
-  const source = message.source as SettlementSource | undefined
-  if (source?.kind === 'subagent-settled') return true
-  return source?.kind === 'subagent-report'
-    && source.senderSessionId !== undefined
+/**
+ * Which `subagent-settled` notices to suppress: `all` silences the runtime's
+ * settlement bookkeeping for every child; `side-children` silences only
+ * children registered by this plugin and lets orchestration-owned children
+ * settle loudly into their parent.
+ */
+export type SettlementNoticeScope = 'all' | 'side-children'
+
+function isRegisteredSideChild(source: SettlementSource | undefined, children: ReadonlySet<SessionId>): boolean {
+  return source?.senderSessionId !== undefined
     && children.has(source.senderSessionId as SessionId)
+}
+
+function isSideChildDelivery(
+  message: UserMessage,
+  children: ReadonlySet<SessionId>,
+  settledScope: SettlementNoticeScope,
+): boolean {
+  const source = message.source as SettlementSource | undefined
+  if (source?.kind === 'subagent-settled') {
+    return settledScope === 'all' || isRegisteredSideChild(source, children)
+  }
+  return source?.kind === 'subagent-report' && isRegisteredSideChild(source, children)
 }
 
 /**
  * Install the parent-inbox boundary for side settlement notices.
  * @param ctx - root plugin context, used to protect future/resumed agents.
+ * @param settledScope - which `subagent-settled` notices to suppress.
  */
-export function createSettlementSilence(ctx: Context): SettlementSilence {
+export function createSettlementSilence(
+  ctx: Context,
+  settledScope: SettlementNoticeScope = 'all',
+): SettlementSilence {
   const children = loadChildren()
   const patched = new Map<Agent, ReadonlyMap<DeliveryMethod, PropertyDescriptor | undefined>>()
 
@@ -91,7 +115,7 @@ export function createSettlementSilence(ctx: Context): SettlementSilence {
         configurable: true,
         writable: true,
         value(message: UserMessage): void {
-          if (!isSideChildDelivery(message, children)) original.call(agent, message)
+          if (!isSideChildDelivery(message, children, settledScope)) original.call(agent, message)
         },
       })
     }

--- a/tests/settle-silence.spec.ts
+++ b/tests/settle-silence.spec.ts
@@ -41,7 +41,7 @@ function fakeAgent(): Agent & { delivered: { method: string; message: UserMessag
   } as unknown as Agent & { delivered: { method: string; message: UserMessage }[] }
 }
 
-function setup(liveAgents: Agent[] = []) {
+function setup(liveAgents: Agent[] = [], settledScope?: 'all' | 'side-children') {
   const created = { handler: undefined as ((payload: { agent: Agent }) => void) | undefined }
   const dispose = vi.fn()
   const ctx = {
@@ -51,7 +51,7 @@ function setup(liveAgents: Agent[] = []) {
       return dispose
     },
   }
-  return { silence: createSettlementSilence(ctx as never), created, dispose }
+  return { silence: createSettlementSilence(ctx as never, settledScope), created, dispose }
 }
 
 beforeEach(() => {
@@ -124,6 +124,51 @@ describe('createSettlementSilence', () => {
     parent.followup(notice(SIDE))
     expect(parent.delivered).toEqual([{ method: 'followup', message: notice(SIDE) }])
     expect(dispose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createSettlementSilence with settlementSilence: side-children', () => {
+  it('still drops settlement notices from registered side children', () => {
+    const { silence } = setup([], 'side-children')
+    const parent = fakeAgent()
+    silence.noteChild(parent, SIDE)
+    parent.followup(notice(SIDE))
+    parent.steer(notice(SIDE))
+    parent.inject(notice(SIDE))
+    expect(parent.delivered).toEqual([])
+  })
+
+  it('still drops explicit reports from registered side children', () => {
+    const { silence } = setup([], 'side-children')
+    const parent = fakeAgent()
+    silence.noteChild(parent, SIDE)
+    parent.followup(notice(SIDE, 'subagent-report'))
+    expect(parent.delivered).toEqual([])
+  })
+
+  it('passes settlement notices from children this plugin never registered', () => {
+    const { silence } = setup([], 'side-children')
+    const parent = fakeAgent()
+    silence.noteChild(parent, SIDE)
+    parent.steer(notice(OTHER))
+    parent.followup(notice(OTHER))
+    expect(parent.delivered).toEqual([
+      { method: 'steer', message: notice(OTHER) },
+      { method: 'followup', message: notice(OTHER) },
+    ])
+  })
+
+  it('keeps the registry durable for side-children scoping across restarts', () => {
+    const first = setup([], 'side-children')
+    first.silence.noteChild(fakeAgent(), SIDE)
+    first.silence.dispose()
+
+    const restarted = setup([], 'side-children')
+    const resumedParent = fakeAgent()
+    restarted.created.handler?.({ agent: resumedParent })
+    resumedParent.followup(notice(SIDE))
+    resumedParent.followup(notice(OTHER))
+    expect(resumedParent.delivered).toEqual([{ method: 'followup', message: notice(OTHER) }])
   })
 })
 


### PR DESCRIPTION
## 问题

`settle-silence` 自 6c0880e 起对所有 Agent 的 `followup/steer/inject` 打补丁并无条件丢弃**一切** `subagent-settled` 通知。这超出了侧会话隔离的意图范围：非 sidechain 创建的 continuable 子代理（例如通过 `subagent_with_model` 做后台编排 fan-out 的子代理）的完成通知同样被吞掉，父会话模型永远收不到「子代理已结算」的入账，编排工作流被迫盲等或轮询。

DSH 的 subagent 运行时把结算通知视为父代理应得的账务（`continuation.ts` 注释："settlement is something the parent is owed an account of"），而本插件的全局吞没破坏了这一契约。

## 修复

新增 `settlementSilence` 配置项（`'all' | 'side-children'`）：

- **`all`（默认）**：维持 6c0880e 的现有行为，对现有用户零变更
- **`side-children`**：`subagent-settled` 与 `subagent-report` 走同一套成员检查——只抑制本插件通过 `reserveChild`/`noteChild` 注册过的侧会话子级（注册表已持久化到 `DSH_HOME/sidechain-children.json`，跨重启可靠），其余子代理的结算通知正常投递

侧会话面板 UI 驱动的场景用默认值即可；编排场景将 `settlementSilence: side-children` 写入配置即可两全。

## 验证

- `pnpm run check`：typecheck ✅、**121/121 测试通过**（新增 4 个 `side-children` 模式用例，含跨重启注册表持久化）、build ✅
- 默认模式行为不变：既有「drops any runtime settlement notice」用例原样通过